### PR TITLE
adding in timestep estimation routine

### DIFF
--- a/spyro/__init__.py
+++ b/spyro/__init__.py
@@ -5,6 +5,7 @@ from .receivers.Receivers import Receivers
 from .sources.Sources import Sources
 from .utils import utils
 from .utils.geometry_creation import create_transect, create_2d_grid, insert_fixed_value
+from .utils.estimate_timestep import estimate_timestep
 from .io import io
 from . import solvers
 
@@ -16,6 +17,7 @@ __all__ = [
     "Receivers",
     "create_transect",
     "create_2d_grid",
+    "estimate_timestep",
     "insert_fixed_value",
     "Sources",
     "solvers",

--- a/spyro/utils/__init__.py
+++ b/spyro/utils/__init__.py
@@ -1,3 +1,3 @@
-from . import utils, geometry_creation
+from . import utils, geometry_creation, estimate_timestep
 
-__all__ = ["utils", "geometry_creation"]
+__all__ = ["utils", "geometry_creation", "estimate_timestep"]

--- a/spyro/utils/estimate_timestep.py
+++ b/spyro/utils/estimate_timestep.py
@@ -31,7 +31,7 @@ def estimate_timestep(mesh, V, c, estimate_max_eigenvalue=True):
     Asp = scipy.sparse.csr_matrix((av, aj, ai))
     Asp_inv = scipy.sparse.csr_matrix((av_inv, aj, ai))
 
-    K = fd.assemble(c * c * dot(grad(u), grad(v)) * dxlump)
+    K = fd.assemble(c*c*dot(grad(u), grad(v)) * dxlump)
     ai, aj, av = K.petscmat.getValuesCSR()
     Ksp = scipy.sparse.csr_matrix((av, aj, ai))
 
@@ -41,6 +41,10 @@ def estimate_timestep(mesh, V, c, estimate_max_eigenvalue=True):
         # absolute maximum of diagonals
         max_eigval = np.amax(np.abs(Lsp.diagonal()))
     else:
+        print(
+            "Computing exact eigenvalues is extremely computationally demanding!",
+            flush=True,
+        )
         max_eigval = scipy.sparse.linalg.eigs(
             Ksp, M=Asp, k=1, which="LM", return_eigenvectors=False
         )[0]
@@ -48,6 +52,7 @@ def estimate_timestep(mesh, V, c, estimate_max_eigenvalue=True):
     # print(max_eigval)
     max_dt = np.float(2 / np.sqrt(max_eigval))
     print(
-        f"Maximum stable timestep should be about: {np.float(2 / np.sqrt(max_eigval))} seconds"
+        f"Maximum stable timestep should be about: {np.float(2 / np.sqrt(max_eigval))} seconds",
+        flush=True,
     )
     return max_dt

--- a/spyro/utils/estimate_timestep.py
+++ b/spyro/utils/estimate_timestep.py
@@ -1,14 +1,19 @@
 import scipy
 import numpy as np
-from scipy.sparse.linalg import inv
 
 import firedrake as fd
 from firedrake import dot, grad
 import finat
 
 
-def estimate_timestep(mesh, V, c):
-    """Estimate the maximum stable timestep based on the spectral radius"""
+def estimate_timestep(mesh, V, c, estimate_max_eigenvalue=True):
+    """Estimate the maximum stable timestep based on the spectral radius
+    using optionally the Gershgorin Circle Theorem to estimate the
+    maximum generalized eigenvalue. Otherwise computes the maximum
+    generalized eigenvalue exactly
+
+    ONLY WORKS WITH KMV ELEMENTS
+    """
 
     u, v = fd.TrialFunction(V), fd.TestFunction(V)
     quad_rule = finat.quadrature.make_quadrature(
@@ -17,8 +22,14 @@ def estimate_timestep(mesh, V, c):
     dxlump = fd.dx(rule=quad_rule)
     A = fd.assemble(u * v * dxlump)
     ai, aj, av = A.petscmat.getValuesCSR()
+    av_inv = []
+    for value in av:
+        if value == 0:
+            av_inv.append(0.0)
+        else:
+            av_inv.append(1 / value)
     Asp = scipy.sparse.csr_matrix((av, aj, ai))
-    Asp_inv = inv(Asp)
+    Asp_inv = scipy.sparse.csr_matrix((av_inv, aj, ai))
 
     K = fd.assemble(c * c * dot(grad(u), grad(v)) * dxlump)
     ai, aj, av = K.petscmat.getValuesCSR()
@@ -26,13 +37,17 @@ def estimate_timestep(mesh, V, c):
 
     # operator
     Lsp = Asp_inv.multiply(Ksp)
+    if estimate_max_eigenvalue:
+        # absolute maximum of diagonals
+        max_eigval = np.amax(np.abs(Lsp.diagonal()))
+    else:
+        max_eigval = scipy.sparse.linalg.eigs(
+            Ksp, M=Asp, k=1, which="LM", return_eigenvectors=False
+        )[0]
 
-    max_eigval = scipy.sparse.linalg.eigs(
-        Lsp, k=1, which="LM", return_eigenvectors=False
-    )
     # print(max_eigval)
-    max_dt = np.float(2 / np.sqrt(max_eigval[0]))
+    max_dt = np.float(2 / np.sqrt(max_eigval))
     print(
-        f"Maximum stable timestep should be about: {np.float(2 / np.sqrt(max_eigval[0]))} seconds"
+        f"Maximum stable timestep should be about: {np.float(2 / np.sqrt(max_eigval))} seconds"
     )
     return max_dt

--- a/spyro/utils/estimate_timestep.py
+++ b/spyro/utils/estimate_timestep.py
@@ -1,0 +1,38 @@
+import scipy
+import numpy as np
+from scipy.sparse.linalg import inv
+
+import firedrake as fd
+from firedrake import dot, grad
+import finat
+
+
+def estimate_timestep(mesh, V, c):
+    """Estimate the maximum stable timestep based on the spectral radius"""
+
+    u, v = fd.TrialFunction(V), fd.TestFunction(V)
+    quad_rule = finat.quadrature.make_quadrature(
+        V.finat_element.cell, V.ufl_element().degree(), "KMV"
+    )
+    dxlump = fd.dx(rule=quad_rule)
+    A = fd.assemble(u * v * dxlump)
+    ai, aj, av = A.petscmat.getValuesCSR()
+    Asp = scipy.sparse.csr_matrix((av, aj, ai))
+    Asp_inv = inv(Asp)
+
+    K = fd.assemble(c * c * dot(grad(u), grad(v)) * dxlump)
+    ai, aj, av = K.petscmat.getValuesCSR()
+    Ksp = scipy.sparse.csr_matrix((av, aj, ai))
+
+    # operator
+    Lsp = Asp_inv.multiply(Ksp)
+
+    max_eigval = scipy.sparse.linalg.eigs(
+        Lsp, k=1, which="LM", return_eigenvectors=False
+    )
+    # print(max_eigval)
+    max_dt = np.float(2 / np.sqrt(max_eigval[0]))
+    print(
+        f"Maximum stable timestep should be about: {np.float(2 / np.sqrt(max_eigval[0]))} seconds"
+    )
+    return max_dt


### PR DESCRIPTION
* Estimates the spectral radius of the operator based on http://homepage.tudelft.nl/a1k53/Papers/Journal/GJI196_2_Mulder.pdf
* Generally, timestep must be slightly lower than this to maintain numerical stability. 